### PR TITLE
Added documentation of DESC data products

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,6 @@ For 1-4, we are asking these people to come up with a contained menu of options 
 * For each of our white papers, we will have a dedicated section on the benefits of external datasets.  This will include ones from Euclid, WFIRST and other spectroscopic surveys.  
 * Our process will be totally transparent and our github page will be public - there is nothing that needs to be hidden about our deliberations.  However, we want to maintain a ‘unified front’ within DESC, so we ask for everyone to refrain from stating any conclusions of the task force until these conclusions have been reached.
 * Endorsement of strategies outside of DESC will be done within the DESC white papers.
+
+## DESC work:
+- documentation of the data products such as dither strategies and simlibs [created for DESC work](doc/README.md)

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,1 +1,2 @@
 # Contents
+- [Data Products](data_products.md)

--- a/doc/data_products.md
+++ b/doc/data_products.md
@@ -1,0 +1,8 @@
+# Data Products
+
+## From within DESC
+- desc dithers : created by [code from Humna Awan](../code/descDithers). Located on nersc at `/global/homes/a/awan/desc/wp_descDithers_csvs`
+
+- simlibs : created by [`OpSimSummary`](https://github.com/rbiswas4/OpSimSummary) and located on nersc at `/global/project/projectdirs/lsst/cadence_outputs/simlibs_whitepaper_call/newsimlibs`. Note these use the `desc dithers` above.
+
+


### PR DESCRIPTION
Added documentation for location of DESC products being created linked from the top-level `README.md`.

	modified:   README.md
	modified:   doc/README.md
	new file:   doc/data_products.md


Fixes #8 